### PR TITLE
fixed the overflow in the footer

### DIFF
--- a/src/scss/layout/_footer.scss
+++ b/src/scss/layout/_footer.scss
@@ -1,6 +1,6 @@
 .footer{
-    background-color:var(--footer_background);
-    height: 461px;
+    background-color: var(--footer_background);
+
 
     &__container{
         display: grid;
@@ -15,6 +15,14 @@
             display: flex;
             flex-direction: row;
         }
+
+        &:not(.footer__section--logo){
+            padding-left: 80px;
+        }
+
+        @include breakpoint("lg") {
+            padding-left: 0;
+        }
     }
 
     &__logo{
@@ -26,8 +34,7 @@
 
     &__title{
         @include fontStyle(var(--white),30px);
-        width: 218px;
-        height: 108px;
+        max-width: 218px;
         margin: 80px 0 32px 17px;
     }
 
@@ -41,8 +48,7 @@
 
     &__paragraph{
         @include fontStyle(var(--white),16px);
-        width: 302px;
-        height: 117px;
+        max-width: 302px;
         font-weight: normal;
         line-height: 18px;
     }
@@ -59,23 +65,28 @@
 
     &__links{
         @include fontStyle(var(--white),14px);
-        padding: 5px 3px;
+        margin: 5px 3px;
         line-height: 16px;
         margin-bottom: 25px;
     }
 
     &__button{
-        @include fontStyle(var(--button_content),24px);
+        @include fontStyle(var(--button_content),16px);
         display: flex;
-        align-items: center;
+        align-items: flex-start;
         justify-content: center;
-        width: 300px;
-        height: 60px;
-        background:var(--footer_button);
+        width: max-content;
+        padding: 12px 24px;       
+        background-color: var(--footer_button);
         border-radius: 60px;
-        line-height: 28px;
         border-style: none;
         margin-bottom: 44px;
+        margin-right: 18px; 
+
+        @include breakpoint("lg"){
+            @include fontStyle(var(--button_content),24px);
+            padding: 16px 64px;
+        }
     }
 
     &__image{
@@ -99,16 +110,9 @@
 
 @media(max-width:1023px){
     .footer{
-        height: auto;
-        
-        &__section:not(.footer__section--logo){
-            padding-left: 80px;
-        }
 
         &__container{
             grid-template-columns: auto;
         }
     }
 }
-
-


### PR DESCRIPTION
# FooCamp - Escuela de Robotica

## Trello ticket
[Bug: Overflow en el footer](https://trello.com/c/6NfknziK/34-bug-overflow-en-el-footer)

## Description
The fixed height of the footer was removed in order to fix the overflow.

## To reproduce

1. Run the project
2. Open the `http://localhost:8080/` page
3. Check footer components in different viewports, especially in large and extra-large sizes.

## Screenshots
<img width="1027" alt="Captura de Pantalla 2021-10-04 a la(s) 9 33 34 p  m" src="https://user-images.githubusercontent.com/32691511/135951385-ccd6d9fc-5ba0-4a6c-a60c-64563359c256.png">

<img width="828" alt="Captura de Pantalla 2021-10-04 a la(s) 9 34 16 p  m" src="https://user-images.githubusercontent.com/32691511/135951397-71c7e7ce-8d4c-4907-b334-b0d5bb412a08.png">


