### PR TITLE
fixed overlapping in the header in small viewports

### DIFF
--- a/src/scss/layout/_header.scss
+++ b/src/scss/layout/_header.scss
@@ -8,9 +8,12 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    height: 80px;
     background-color: var(--white);
-    padding: 31px 80px 31px 90px;
+    padding: 31px 80px 31px 40px;
+
+    @include breakpoint("md") {
+        padding: 31px 80px 31px 90px;
+    }
 }
 
 .header__item, .header___link {
@@ -40,10 +43,23 @@
 
 .header__links {
     list-style: none;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    margin-left: 30px;
+
+    @include breakpoint("md") {
+        flex-direction: row;
+        flex-wrap: nowrap;
+    }
 
     .header__item {
-        display: inline-block;
         padding-left: 30px;
+        margin-bottom: 10px;
+
+        @include breakpoint("md") {
+            margin-bottom: 0;
+        }
     }
 
     .header__item .header__btn {
@@ -52,7 +68,7 @@
         border-radius: 30px;
         cursor: pointer;
         border: var(--white);
-
+            
         @include breakpoint("md") {
             padding: 11px 42px;
         }

--- a/src/scss/layout/_header.scss
+++ b/src/scss/layout/_header.scss
@@ -48,9 +48,13 @@
 
     .header__item .header__btn {
         background-color: var(--btndonacion);
-        padding: 11px 42px;
+        padding: 6px 20px;
         border-radius: 30px;
         cursor: pointer;
         border: var(--white);
+
+        @include breakpoint("md") {
+            padding: 11px 42px;
+        }
     }
 }


### PR DESCRIPTION
# FooCamp - Escuela de Robotica

## Trello ticket
[Bug: Overlapping en el header](https://trello.com/c/GA39nBPD/36-bug-overlapping-en-el-header)

## Description
1. Applied Flexbox to the elements with the class `.header__links` in order to avoid overlapping between the items in the navbar in the header.

2. The padding of the button `DONACIONES` was decreased in the small viewport in order to prevent overflow on the left side. 

## To reproduce

1. Run the project
2. Open the `http://localhost:8080/` page
3. Check the header, especially in medium and small viewports.

## Screenshots
Header in medium and small viewports
<img width="629" alt="Captura de Pantalla 2021-10-04 a la(s) 10 17 11 p  m" src="https://user-images.githubusercontent.com/32691511/135954667-bfa41fa2-8275-467b-b18a-ffcec8b9d098.png">

<img width="603" alt="Captura de Pantalla 2021-10-04 a la(s) 10 17 19 p  m" src="https://user-images.githubusercontent.com/32691511/135954676-6bb9d1d1-f93c-4ce5-bc72-2508d62e1522.png">

